### PR TITLE
Update multi-master.md

### DIFF
--- a/docs/multi-master.md
+++ b/docs/multi-master.md
@@ -31,6 +31,8 @@ An example config file:
 
 ## Config File
 
+**Note: When setting up multi-master in a config file, make sure to enable `multi-master` and `active-replica` BEFORE setting your `replicaof` commands, as shown in the examples below, otherwise multi-master replication may not work correctly.** 
+
 Instance-A config file:
 
 ```


### PR DESCRIPTION
If you set replicaof before enabling multi-master and active-replica in a configuration file, multi-master replication won't be set up correctly (as the replicaof configurations will be parsed before the server knows that multi-master is enabled, which will result in incorrect master-master configuration). This update to documentation is to explicitly state that ordering of multi-master and replicaof lines matter. 

Related to https://github.com/EQ-Alpha/KeyDB/issues/213.